### PR TITLE
Rework the entire thing to check only one interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# wait-for-interfaces - delay a systemd service's startup until an net interface is online
+# wait-for-interfaces - delay a systemd service's startup until a net interface is online
 
 Say you have a machine on a tunnel/wireguard/tailscale tailnet, and you'd like some service on that machine to listen only on that network: So you put `listenAddr = 100.90.64.81:9010` in your fictional service's configuration, and that works! Except, if the tailscale interface isn't ready yet, your service will refuse to start because the IP address isn't available for listening on.
 
@@ -8,23 +8,23 @@ This tool can help there - by adding it to your service's `ExecStartPre` systemd
 
 ### In plain systemd units
 
-First, identify the interfaces that need waiting-on. Usually that's one, but you can have as many as you like; only once all interfaces are online will the startup process for your services begin.
+First, identify the interface that needs waiting on.
 
-Then, identify the services that depend on those interfaces.
+Then, identify the services that depend on that interface.
 
 And then, add the following to their unit files (assuming you want to wait for `tailscale0` and `utun3`):
 
 ```systemd
-ExecStartPre = +/path/to/wait-for-interfaces tailscale0 utun3
+ExecStartPre = +/path/to/wait-for-interfaces -interface tailscale0
 ```
 
 Then, upon a restart of the unit you should see something like the following:
 
 ```console
-Feb 09 14:00:44 gloria wait-for-interfaces[2019948]: wait-for-interfaces: Interface tailscale0 has address ip+net/100.70.151.16/32
-Feb 09 14:00:44 gloria wait-for-interfaces[2019948]: wait-for-interfaces: Interface tailscale0 has address ip+net/fd7a:115c:a1e0::a501:9711/128
-Feb 09 14:00:44 gloria wait-for-interfaces[2019948]: wait-for-interfaces: Interface tailscale0 has address ip+net/fe80::2d53:df2d:f9ff:7d04/64
-Feb 09 14:00:44 gloria wait-for-interfaces[2019948]: wait-for-interfaces: All interfaces out of [tailscale0] are up!
+Feb 09 14:00:44 gloria wait-for-interfaces[2019948]: wait-for-interfaces(tailscale0): Interface tailscale0 has address ip+net/100.70.151.16/32
+Feb 09 14:00:44 gloria wait-for-interfaces[2019948]: wait-for-interfaces(tailscale0): Interface tailscale0 has address ip+net/fd7a:115c:a1e0::a501:9711/128
+Feb 09 14:00:44 gloria wait-for-interfaces[2019948]: wait-for-interfaces(tailscale0): Interface tailscale0 has address ip+net/fe80::2d53:df2d:f9ff:7d04/64
+Feb 09 14:00:44 gloria wait-for-interfaces[2019948]: wait-for-interfaces(tailscale0): interfaces tailscale0 is up.
 ```
 
 ### In nixos

--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,7 @@
       imports = [
         inputs.flake-parts.flakeModules.easyOverlay
         inputs.flake-parts.flakeModules.partitions
+        ./nixos/tests/flake-part.nix
       ];
       systems = ["x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin"];
       perSystem = {

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -26,7 +26,7 @@
     networking.wait-for-interfaces = mkOption {
       description = "An attrset mapping an interface name to services and sockets that depend on the interface being online.";
       type = types.attrsOf (types.submodule wfiSubmodule);
-      default = [];
+      default = {};
       example = {
         tailscale0 = {
           services = ["prometheus-node-exporter"];

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -7,12 +7,12 @@
   options = with lib; let
     wfiSubmodule.options = {
       services = mkOption {
-        description = "Services that depend on the listed interfaces";
+        description = "Services that depend on the given interface";
         type = types.listOf types.str;
         default = [];
       };
       sockets = mkOption {
-        description = "Sockets that depend on the listed interfaces";
+        description = "Sockets that depend on the given interface";
         type = types.listOf types.str;
         default = [];
       };
@@ -30,13 +30,14 @@
       example = {
         tailscale0 = {
           services = ["prometheus-node-exporter"];
+          sockets = ["homeauth"];
         };
       };
     };
   };
 
   config = let
-    cmdline = interface: {requireIPs, ...}: (map (ip: "-ip=${ip}") requireIPs) ++ [interface];
+    cmdline = interface: {requireIPs, ...}: (map (ip: "-ip=${ip}") requireIPs) ++ ["-interface=${interface}"];
     addServiceDependencies = interface: args @ {services, ...}:
       lib.listToAttrs (map
         (service: {

--- a/nixos/tests/e2e/default.nix
+++ b/nixos/tests/e2e/default.nix
@@ -1,0 +1,9 @@
+{
+  pkgs,
+  nixos-lib,
+  nixosModule,
+  ...
+}: {
+  service = import ./service.nix {inherit pkgs nixos-lib nixosModule;};
+  socket = import ./socket.nix {inherit pkgs nixos-lib nixosModule;};
+}

--- a/nixos/tests/e2e/service.nix
+++ b/nixos/tests/e2e/service.nix
@@ -1,0 +1,43 @@
+{
+  pkgs,
+  nixos-lib,
+  nixosModule,
+}: let
+  stunPort = 3478;
+in
+  nixos-lib.runTest {
+    name = "service-wait-for-interfaces-nixos";
+    hostPkgs = pkgs;
+
+    nodes.machine = {
+      config,
+      pkgs,
+      lib,
+      ...
+    }: {
+      imports = [
+        nixosModule
+      ];
+
+      environment.systemPackages = [
+      ];
+      virtualisation.cores = 4;
+      virtualisation.memorySize = 1024;
+
+      services.prometheus.exporters.node = {
+        enable = true;
+        listenAddress = "127.0.0.50";
+      };
+      networking.wait-for-interfaces.lo = {
+        services = ["prometheus-node-exporter"];
+        requireIPs = ["127.0.0.50"];
+      };
+    };
+
+    testScript = ''
+      machine.start()
+      machine.wait_until_succeeds("systemctl show - prometheus-node-exporter | grep 'ActiveState=activating'")
+      machine.succeed("ip address add 127.0.0.50/32 dev lo")
+      machine.wait_for_unit("prometheus-node-exporter")
+    '';
+  }

--- a/nixos/tests/e2e/socket.nix
+++ b/nixos/tests/e2e/socket.nix
@@ -1,0 +1,57 @@
+{
+  pkgs,
+  nixos-lib,
+  nixosModule,
+}: let
+  stunPort = 3478;
+in
+  nixos-lib.runTest {
+    name = "socket-wait-for-interfaces-nixos";
+    hostPkgs = pkgs;
+
+    nodes.machine = {
+      config,
+      pkgs,
+      lib,
+      ...
+    }: {
+      imports = [
+        nixosModule
+      ];
+
+      environment.systemPackages = [
+      ];
+      virtualisation.cores = 4;
+      virtualisation.memorySize = 1024;
+
+      systemd.sockets.testing = {
+        wantedBy = ["multi-user.target"];
+        requires = ["setup-testing-socket.service"];
+        after = ["setup-testing-socket.service"];
+        socketConfig = {
+          ListenStream = "192.168.10.50:3000";
+        };
+      };
+      systemd.services.setup-testing-socket = {
+        # Ensure that the system can start up before we run tests - it
+        # is sockets.target, and it looks like startup of all sockets is
+        # required for machine.start() to finish.
+        script = "${pkgs.iproute2}/bin/ip address add 192.168.10.50/32 dev lo";
+        wantedBy = ["multi-user.target"];
+        unitConfig.DefaultDependencies = false;
+      };
+      systemd.services.testing = {
+        wantedBy = ["multi-user.target"];
+        script = "echo hi";
+      };
+      networking.wait-for-interfaces.lo = {
+        sockets = ["testing"];
+        requireIPs = ["192.168.10.50"];
+      };
+    };
+
+    testScript = ''
+      machine.start()
+      machine.wait_for_unit("testing.socket")
+    '';
+  }

--- a/nixos/tests/flake-part.nix
+++ b/nixos/tests/flake-part.nix
@@ -1,0 +1,37 @@
+# Tests for the nixos module. Intended to be invoked via & merged into
+# the flake's check attribute.
+{
+  self,
+  lib,
+  pkgs',
+  inputs,
+  withSystem,
+  ...
+}: {
+  perSystem = {
+    config,
+    pkgs,
+    final,
+    system,
+    ...
+  }: {
+    checks = let
+      nixos-lib = import "${inputs.nixpkgs}/nixos/lib" {};
+    in
+      if ! pkgs.lib.hasSuffix "linux" system
+      then {}
+      else let
+        importTests = dir:
+          lib.mapAttrs' (name: value: {
+            name = "${dir}/${name}";
+            inherit value;
+          }) (import ./${dir} {
+            inherit pkgs nixos-lib;
+            nixosModule = self.nixosModules.default;
+          });
+      in
+        lib.mkMerge [
+          (importTests "e2e")
+        ];
+  };
+}


### PR DESCRIPTION
This makes it easier/possible to say "this interface with these IP addresses", which is actually what I want; the flexibility around waiting for multiple interfaces is not something I need much, so it just makes more sense.. and it straightens out the data model w.r.t. the nixos option, too.